### PR TITLE
refactor: use graphql helper for all graphql calls

### DIFF
--- a/src/addressResolvers/snapshot.ts
+++ b/src/addressResolvers/snapshot.ts
@@ -20,6 +20,7 @@ export async function lookupAddresses(addresses: Address[]): Promise<Record<Addr
         }
       }`
     );
+
     return Object.fromEntries(users.filter(user => user.name).map(user => [user.id, user.name]));
   } catch (e) {
     if (!isSilencedError(e)) {

--- a/src/lookupDomains.ts
+++ b/src/lookupDomains.ts
@@ -21,16 +21,14 @@ async function fetchDomainData(domain: Domain, chainId: string): Promise<Domain>
     data: { data }
   } = await graphQlCall(
     constants.ensSubgraph[chainId],
-    `
-      query Registration {
-        registration(id: "0x${hash}") {
-          domain {
-            name
-            labelName
-          }
+    `query Registration {
+      registration(id: "0x${hash}") {
+        domain {
+          name
+          labelName
         }
       }
-    `
+    }`
   );
   const labelName = data?.registration?.domain?.labelName;
 
@@ -53,8 +51,7 @@ export default async function lookupDomains(
       }
     } = await graphQlCall(
       constants.ensSubgraph[chainId],
-      `
-      query Domain {
+      `query Domain {
         account(id: "${address.toLowerCase()}") {
           domains {
             name
@@ -65,8 +62,7 @@ export default async function lookupDomains(
             expiryDate
           }
         }
-      }
-     `
+      }`
     );
 
     const now = (Date.now() / 1000).toFixed(0);

--- a/src/resolvers/snapshot.ts
+++ b/src/resolvers/snapshot.ts
@@ -1,23 +1,20 @@
-import axios from 'axios';
-import { getUrl, resize } from '../utils';
+import { getUrl, graphQlCall, resize } from '../utils';
 import { max } from '../constants.json';
-import { fetchHttpImage, axiosDefaultParams } from './utils';
+import { fetchHttpImage } from './utils';
 
 const HUB_URL = process.env.HUB_URL ?? 'https://hub.snapshot.org';
 
 function createPropertyResolver(property: 'avatar' | 'cover') {
   return async (address: string) => {
     try {
-      const user = (
-        await axios({
-          url: `${HUB_URL}/graphql`,
-          method: 'post',
-          data: {
-            query: `query { user(id: "${address}") { ${property} } }`
-          },
-          ...axiosDefaultParams
-        })
-      ).data.data.user;
+      const {
+        data: {
+          data: { user }
+        }
+      } = await graphQlCall(
+        `${HUB_URL}/graphql`,
+        `query { user(id: "${address}") { ${property} } }`
+      );
 
       if (!user?.[property]) return false;
 

--- a/src/resolvers/space.ts
+++ b/src/resolvers/space.ts
@@ -1,23 +1,19 @@
-import axios from 'axios';
-import { getUrl, resize } from '../utils';
+import { getUrl, graphQlCall, resize } from '../utils';
 import { max } from '../constants.json';
-import { fetchHttpImage, axiosDefaultParams } from './utils';
+import { fetchHttpImage } from './utils';
 
 const HUB_URL = process.env.HUB_URL || 'https://hub.snapshot.org';
 
 export default async function resolve(key) {
   try {
-    const space = (
-      await axios({
-        url: `${HUB_URL}/graphql`,
-        method: 'post',
-        data: {
-          query: `query { space(id: "${key}") { avatar } }`
-        },
-        ...axiosDefaultParams
-      })
-    ).data.data.space;
+    const {
+      data: {
+        data: { space }
+      }
+    } = await graphQlCall(`${HUB_URL}/graphql`, `query { space(id: "${key}") { avatar } }`);
+
     if (!space || !space.avatar) return false;
+
     const url = getUrl(space.avatar);
     const input = await fetchHttpImage(url);
     return await resize(input, max, max);


### PR DESCRIPTION
This refactor is using the `graphQlCall` helper for all graphql calls

This will enable us in #265 to put the api key handling only inside this function