### PR TITLE
chore: yank avatar cache

### DIFF
--- a/src/aws.ts
+++ b/src/aws.ts
@@ -6,7 +6,7 @@ const bucket = process.env.AWS_BUCKET_NAME;
 const region = process.env.AWS_REGION;
 const endpoint = process.env.AWS_ENDPOINT || undefined;
 if (region) client = new AWS.S3({ region, endpoint });
-const dir = 'stamp-5';
+const dir = 'stamp-6';
 
 export async function streamToBuffer(stream: Readable) {
   return await new Promise((resolve, reject) => {


### PR DESCRIPTION
Fix #284 

The cache was not reset after #259, resulting in already created avatars to be served with the default starknet avatar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the S3 configuration to access a new directory, improving data handling for the application. 

- **Bug Fixes**
	- No bug fixes were introduced in this release. 

- **Documentation**
	- No changes to documentation were made in this release. 

- **Chores**
	- No other maintenance tasks were performed in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->