### PR TITLE
fix: update sx subgraph url

### DIFF
--- a/src/resolvers/space-sx.ts
+++ b/src/resolvers/space-sx.ts
@@ -10,8 +10,8 @@ const SUBGRAPH_URLS = [
   'https://api.studio.thegraph.com/query/23545/sx-polygon/version/latest',
   'https://api.studio.thegraph.com/query/23545/sx-arbitrum/version/latest',
   'https://api.studio.thegraph.com/query/23545/sx-optimism/version/latest',
-  'https://api-1.snapshotx.xyz',
-  'https://testnet-api-1.snapshotx.xyz'
+  'https://api-1.snapshot.box',
+  'https://testnet-api-1.snapshot.box'
 ];
 
 async function getSpaceProperty(key: string, url: string, property: 'avatar' | 'cover') {


### PR DESCRIPTION
Update the SX subgraph to the new `.box` domains, instead of old `x.xyz` domains