### PR TITLE
feat: add testnet support to snapshot resolver

### DIFF
--- a/src/constants.json
+++ b/src/constants.json
@@ -15,5 +15,7 @@
   "ensSubgraph": {
     "1": "https://subgrapher.snapshot.org/subgraph/arbitrum/5XqPmWe6gjyrJtFn9cLy237i4cWw2j9HcUJEXsP5qGtH",
     "11155111": "https://api.studio.thegraph.com/proxy/49574/enssepolia/version/latest"
-  }
+  },
+  "defaultOffchainNetwork" : "s",
+  "offchainNetworks": ["s", "s-tn"]
 }

--- a/src/resolvers/snapshot.ts
+++ b/src/resolvers/snapshot.ts
@@ -1,34 +1,48 @@
 import { getUrl, graphQlCall, resize } from '../utils';
-import { max } from '../constants.json';
+import { max, offchainNetworks, defaultOffchainNetwork } from '../constants.json';
 import { fetchHttpImage } from './utils';
 
-const HUB_URL = process.env.HUB_URL ?? 'https://hub.snapshot.org';
+const HUB_URLS = {
+  s: process.env.HUB_URL ?? 'https://hub.snapshot.org',
+  's-tn': process.env.HUB_URL_TN ?? 'https://testnet.hub.snapshot.org'
+};
+
+async function getOffchainProperty(
+  network: string,
+  id: string,
+  entity: 'user' | 'space',
+  property: 'avatar' | 'cover'
+) {
+  try {
+    const {
+      data: {
+        data: { entry }
+      }
+    } = await graphQlCall(
+      `${HUB_URLS[network]}/graphql`,
+      `query { entry: ${entity}(id: "${id}") { ${property} } }`,
+      {
+        headers: { 'x-api-key': process.env.HUB_API_KEY }
+      }
+    );
+
+    if (!entry?.[property]) return false;
+
+    const url = getUrl(entry[property]);
+    const input = await fetchHttpImage(url);
+
+    if (property === 'cover') return input;
+
+    return await resize(input, max, max);
+  } catch (e) {
+    return false;
+  }
+}
 
 function createPropertyResolver(entity: 'user' | 'space', property: 'avatar' | 'cover') {
-  return async (address: string) => {
-    try {
-      const {
-        data: {
-          data: { entry }
-        }
-      } = await graphQlCall(
-        `${HUB_URL}/graphql`,
-        `query { entry: ${entity}(id: "${address}") { ${property} } }`,
-        {
-          headers: { 'x-api-key': process.env.HUB_API_KEY }
-        }
-      );
-
-      if (!entry?.[property]) return false;
-
-      const url = getUrl(entry[property]);
-      const input = await fetchHttpImage(url);
-
-      if (property === 'cover') return input;
-
-      return await resize(input, max, max);
-    } catch (e) {
-      return false;
+  return async (address: string, network = defaultOffchainNetwork) => {
+    if (offchainNetworks.includes(network)) {
+      return getOffchainProperty(network, address, entity, property);
     }
   };
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -54,13 +54,14 @@ export function shortNameToChainId(shortName: string) {
   if (shortName === 'ftm') return '250';
   if (shortName === 'matic') return '137';
   if (shortName === 'arb1') return '42161';
+  if (constants.offchainNetworks.includes(shortName)) return shortName;
 
   return null;
 }
 
 export async function parseQuery(id: string, type: ResolverType, query) {
   let address = id;
-  let network = '1';
+  let network = type.startsWith('space-') ? constants.defaultOffchainNetwork : '1';
 
   // Resolve format
   // let format;

--- a/test/integration/resolvers/snapshot.test.ts
+++ b/test/integration/resolvers/snapshot.test.ts
@@ -9,6 +9,12 @@ describe('resolvers', () => {
         expect(result).toBe(false);
       }, 15e3);
 
+      it('should return false on unsupported network', async () => {
+        const result = await resolvers.snapshot('eth:0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70');
+
+        expect(result).toBe(false);
+      }, 15e3);
+
       it('should resolve', async () => {
         const result = await resolvers.snapshot('0xeF8305E140ac520225DAf050e2f71d5fBcC543e7');
 
@@ -21,6 +27,12 @@ describe('resolvers', () => {
   describe('on user cover', () => {
     it('should return false if missing', async () => {
       const result = await resolvers['user-cover']('0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70');
+
+      expect(result).toBe(false);
+    }, 15e3);
+
+    it('should return false on unsupported network', async () => {
+      const result = await resolvers.snapshot('eth:0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70');
 
       expect(result).toBe(false);
     }, 15e3);
@@ -40,6 +52,12 @@ describe('resolvers', () => {
       expect(result).toBe(false);
     });
 
+    it('should return false on unsupported network', async () => {
+      const result = await resolvers.space('eth:ens.eth');
+
+      expect(result).toBe(false);
+    });
+
     it('should resolve', async () => {
       const result = await resolvers.space('ens.eth');
 
@@ -55,8 +73,14 @@ describe('resolvers', () => {
       expect(result).toBe(false);
     });
 
+    it('should return false on unsupported network', async () => {
+      const result = await resolvers['space-cover']('eth:test.wa0x6e.eth');
+
+      expect(result).toBe(false);
+    });
+
     it('should resolve', async () => {
-      const result = await resolvers['space-cover']('0cf5e.eth');
+      const result = await resolvers['space-cover']('test.wa0x6e.eth');
 
       expect(result).toBeInstanceOf(Buffer);
       expect(result.length).toBeGreaterThan(1000);


### PR DESCRIPTION
Closes https://github.com/snapshot-labs/workflow/issues/220

This PR adds support for testnet on the snapshot resolver (user-avatar, user-cover, space-cover, space-avatar)

This PR introduces a new address format (`NETWORK:ADDRESS`), e.g. `s:ens.eth` or `s-tn:0x91FD2c8d24767db4Ece7069AA27832ffaf8590f3`, while still be backward compatible with the previous `ADDRESS` format

### How to test 

- Mainet space cover: http://localhost:3008/space-cover/test.wa0x6e.eth
- Mainet space cover: http://localhost:3008/space-cover/s:test.wa0x6e.eth 
- Testnet space avatar: http://localhost:3008/space/s-tn:diva-testing.eth
- Testnet user avatar: http://localhost:3008/avatar/s-tn:0x3b4e97c176DD99fE73307F123189F53EeF0BC435?resolver=snapshot (should be same as https://snapshot.4everland.link/ipfs/bafybeiaxlwymw6f76enjaf5errbybrfrv5ak67jxyzf7tucdbmn6tsjor4)

### Note

This is the first step of a refactoring process.

In a later PR, the space-sx resolver will be merge into this one, and the network prefix will  allow targeting the network API, and avoid polling all onchain api on each call