### PR TITLE
feat: add SX support in snapshot resolver

### DIFF
--- a/src/resolvers/snapshot.ts
+++ b/src/resolvers/snapshot.ts
@@ -70,13 +70,14 @@ async function getOnchainProperty(
 }
 
 function createPropertyResolver(entity: Entity, property: Property) {
-  return async (address: string, chainId = '1', networkId = defaultOffchainNetwork) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  return async (address: string, chainId = 1, networkId = defaultOffchainNetwork) => {
     let value = null;
 
     if (!Object.keys(API_URLS).includes(networkId)) return false;
 
     try {
-      if (offchainNetworks.includes(networkId)) {
+      if (offchainNetworks.includes(networkId) || entity === 'user') {
         value = await getOffchainProperty(networkId, address, entity, property);
       } else {
         value = await getOnchainProperty(networkId, address, entity, property);

--- a/src/resolvers/snapshot.ts
+++ b/src/resolvers/snapshot.ts
@@ -78,7 +78,12 @@ function createPropertyResolver(entity: Entity, property: Property) {
 
     try {
       if (offchainNetworks.includes(networkId) || entity === 'user') {
-        value = await getOffchainProperty(networkId, address, entity, property);
+        value = await getOffchainProperty(
+          offchainNetworks.includes(networkId) ? networkId : defaultOffchainNetwork,
+          address,
+          entity,
+          property
+        );
       } else {
         value = await getOnchainProperty(networkId, address, entity, property);
       }

--- a/src/resolvers/snapshot.ts
+++ b/src/resolvers/snapshot.ts
@@ -1,48 +1,97 @@
+import { getAddress } from '@ethersproject/address';
 import { getUrl, graphQlCall, resize } from '../utils';
 import { max, offchainNetworks, defaultOffchainNetwork } from '../constants.json';
 import { fetchHttpImage } from './utils';
+import { isStarknetAddress } from '../addressResolvers/utils';
 
-const HUB_URLS = {
-  s: process.env.HUB_URL ?? 'https://hub.snapshot.org',
-  's-tn': process.env.HUB_URL_TN ?? 'https://testnet.hub.snapshot.org'
+const API_URLS = {
+  s: `${process.env.HUB_URL ?? 'https://hub.snapshot.org'}/graphql`,
+  's-tn': `${process.env.HUB_URL_TN ?? 'https://testnet.hub.snapshot.org'}/graphql`,
+  eth: 'https://api.studio.thegraph.com/query/23545/sx/version/latest',
+  sep: 'https://api.studio.thegraph.com/query/23545/sx-sepolia/version/latest',
+  matic: 'https://api.studio.thegraph.com/query/23545/sx-polygon/version/latest',
+  arb1: 'https://api.studio.thegraph.com/query/23545/sx-arbitrum/version/latest',
+  oeth: 'https://api.studio.thegraph.com/query/23545/sx-optimism/version/latest',
+  sn: 'https://api.snapshot.box',
+  'sn-sep': 'https://testnet-api.snapshot.box'
 };
 
+type Entity = 'user' | 'space';
+type Property = 'avatar' | 'cover';
+
 async function getOffchainProperty(
-  network: string,
+  networkId: string,
   id: string,
-  entity: 'user' | 'space',
-  property: 'avatar' | 'cover'
+  entity: Entity,
+  property: Property
 ) {
-  try {
-    const {
-      data: {
-        data: { entry }
-      }
-    } = await graphQlCall(
-      `${HUB_URLS[network]}/graphql`,
-      `query { entry: ${entity}(id: "${id}") { ${property} } }`,
-      {
-        headers: { 'x-api-key': process.env.HUB_API_KEY }
-      }
-    );
+  const {
+    data: {
+      data: { entry }
+    }
+  } = await graphQlCall(
+    API_URLS[networkId],
+    `query { entry: ${entity}(id: "${id}") { ${property} } }`,
+    {
+      headers: { 'x-api-key': process.env.HUB_API_KEY }
+    }
+  );
 
-    if (!entry?.[property]) return false;
-
-    const url = getUrl(entry[property]);
-    const input = await fetchHttpImage(url);
-
-    if (property === 'cover') return input;
-
-    return await resize(input, max, max);
-  } catch (e) {
-    return false;
-  }
+  return entry?.[property];
 }
 
-function createPropertyResolver(entity: 'user' | 'space', property: 'avatar' | 'cover') {
-  return async (address: string, network = defaultOffchainNetwork) => {
-    if (offchainNetworks.includes(network)) {
-      return getOffchainProperty(network, address, entity, property);
+async function getOnchainProperty(
+  networkId: string,
+  id: string,
+  entity: Entity,
+  property: Property
+) {
+  const ids = [id];
+  if (!isStarknetAddress(id)) {
+    ids.push(getAddress(id));
+  }
+
+  const {
+    data: {
+      data: { spaces }
+    }
+  } = await graphQlCall(
+    API_URLS[networkId],
+    `query {
+      spaces(where: { id_in: [${ids.map(item => `"${item}"`).join(', ')}] }) {
+        metadata {
+          ${property}
+        }
+      }
+    }`
+  );
+
+  return spaces?.map(space => space.metadata?.[property]).filter(Boolean)[0];
+}
+
+function createPropertyResolver(entity: Entity, property: Property) {
+  return async (address: string, chainId = '1', networkId = defaultOffchainNetwork) => {
+    let value = null;
+
+    if (!Object.keys(API_URLS).includes(networkId)) return false;
+
+    try {
+      if (offchainNetworks.includes(networkId)) {
+        value = await getOffchainProperty(networkId, address, entity, property);
+      } else {
+        value = await getOnchainProperty(networkId, address, entity, property);
+      }
+
+      if (!value) return false;
+
+      const url = getUrl(value);
+      const input = await fetchHttpImage(url);
+
+      if (property === 'cover') return input;
+
+      return await resize(input, max, max);
+    } catch (e) {
+      return false;
     }
   };
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -54,14 +54,14 @@ export function shortNameToChainId(shortName: string) {
   if (shortName === 'ftm') return '250';
   if (shortName === 'matic') return '137';
   if (shortName === 'arb1') return '42161';
-  if (constants.offchainNetworks.includes(shortName)) return shortName;
 
   return null;
 }
 
 export async function parseQuery(id: string, type: ResolverType, query) {
   let address = id;
-  let network = type.startsWith('space-') ? constants.defaultOffchainNetwork : '1';
+  let network = '1';
+  let networkId: string | null = null;
 
   // Resolve format
   // let format;
@@ -70,6 +70,7 @@ export async function parseQuery(id: string, type: ResolverType, query) {
     // format = 'eip3770';
     address = chunks[1];
     network = shortNameToChainId(chunks[0]) || '1';
+    networkId = chunks[0] || constants.defaultOffchainNetwork;
   } else if (chunks.length === 3) {
     // format = 'caip10';
     address = chunks[2];
@@ -93,6 +94,7 @@ export async function parseQuery(id: string, type: ResolverType, query) {
   return {
     address,
     network,
+    networkId,
     w,
     h,
     fallback: query.fb === 'jazzicon' ? 'jazzicon' : 'blockie',

--- a/test/integration/resolvers/snapshot.test.ts
+++ b/test/integration/resolvers/snapshot.test.ts
@@ -9,14 +9,15 @@ describe('resolvers', () => {
         expect(result).toBe(false);
       });
 
-      it('should return false on unsupported network', async () => {
+      it('should resolve regardless of network', async () => {
         const result = await resolvers.snapshot(
           '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7',
           1,
           'eth'
         );
 
-        expect(result).toBe(false);
+        expect(result).toBeInstanceOf(Buffer);
+        expect(result.length).toBeGreaterThan(1000);
       });
 
       it('should resolve', async () => {
@@ -35,14 +36,15 @@ describe('resolvers', () => {
       expect(result).toBe(false);
     });
 
-    it('should return false on unsupported network', async () => {
+    it('should resolve regardless of network', async () => {
       const result = await resolvers.snapshot(
         '0xf1f09AdC06aAB740AA16004D62Dbd89484d3Be90',
         1,
         'eth'
       );
 
-      expect(result).toBe(false);
+      expect(result).toBeInstanceOf(Buffer);
+      expect(result.length).toBeGreaterThan(1000);
     });
 
     it('should resolve', async () => {

--- a/test/integration/resolvers/snapshot.test.ts
+++ b/test/integration/resolvers/snapshot.test.ts
@@ -7,20 +7,24 @@ describe('resolvers', () => {
         const result = await resolvers.snapshot('0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70');
 
         expect(result).toBe(false);
-      }, 15e3);
+      });
 
       it('should return false on unsupported network', async () => {
-        const result = await resolvers.snapshot('eth:0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70');
+        const result = await resolvers.snapshot(
+          '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7',
+          1,
+          'eth'
+        );
 
         expect(result).toBe(false);
-      }, 15e3);
+      });
 
       it('should resolve', async () => {
         const result = await resolvers.snapshot('0xeF8305E140ac520225DAf050e2f71d5fBcC543e7');
 
         expect(result).toBeInstanceOf(Buffer);
         expect(result.length).toBeGreaterThan(1000);
-      }, 15e3);
+      });
     });
   });
 
@@ -29,20 +33,24 @@ describe('resolvers', () => {
       const result = await resolvers['user-cover']('0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70');
 
       expect(result).toBe(false);
-    }, 15e3);
+    });
 
     it('should return false on unsupported network', async () => {
-      const result = await resolvers.snapshot('eth:0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70');
+      const result = await resolvers.snapshot(
+        '0xf1f09AdC06aAB740AA16004D62Dbd89484d3Be90',
+        1,
+        'eth'
+      );
 
       expect(result).toBe(false);
-    }, 15e3);
+    });
 
     it('should resolve', async () => {
       const result = await resolvers['user-cover']('0xf1f09AdC06aAB740AA16004D62Dbd89484d3Be90');
 
       expect(result).toBeInstanceOf(Buffer);
       expect(result.length).toBeGreaterThan(1000);
-    }, 15e3);
+    });
   });
 
   describe('on space avatar', () => {
@@ -53,7 +61,7 @@ describe('resolvers', () => {
     });
 
     it('should return false on unsupported network', async () => {
-      const result = await resolvers.space('eth:ens.eth');
+      const result = await resolvers.space('ens.eth', 1, 'eth');
 
       expect(result).toBe(false);
     });
@@ -74,7 +82,7 @@ describe('resolvers', () => {
     });
 
     it('should return false on unsupported network', async () => {
-      const result = await resolvers['space-cover']('eth:test.wa0x6e.eth');
+      const result = await resolvers['space-cover']('test.wa0x6e.eth', 1, 'eth');
 
       expect(result).toBe(false);
     });


### PR DESCRIPTION
Toward https://github.com/snapshot-labs/workflow/issues/220

This PR adds support for SX space and avatar in the snapshot resolver, and is the first step into merging all snapshot related resolver (snapshot and space-sx) into one single resolver.

This merging is now possible since https://github.com/stamp-labs/stamp/pull/308, which introduces network prefix for all IDs (e.g. `eth:0x00` or `s:snapshot.eth`), and enable network distinction from the ID itself.

Instead of having 

- `space-cover/ens.eth`
- `space-cover-sx/0x0xxxx` 

We could simply have 

- `space-cover/s:ens.eth`
- `space-cover/eth:0x0xxxx`

This update also improves the performance on the SX resolving side, since the network prefix enable us to target a specific API endpoint, instead of polling all SX endpoint on each request.

For backward compatibility, old `space-cover-sx` and `space-sx` resolver are still preserved, and will be removed in step 2, once we confirmed everything is working, and UI is migrated to the new url format.

### How to test 

- http://localhost:3008/space-cover/s:test.wa0x6e.eth
- http://localhost:3008/space/s:test.wa0x6e.eth
- http://localhost:3008/space/s-tn:diva-testing.eth
- http://localhost:3008/space/sn:0x07c251045154318a2376a3bb65be47d3c90df1740d8e35c9b9d943aa3f240e50
- http://localhost:3008/space-cover/sn:0x07c251045154318a2376a3bb65be47d3c90df1740d8e35c9b9d943aa3f240e50

All urls above should work