### PR TITLE
fix: fix legacy snapshot resolver not working

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -61,7 +61,7 @@ export function shortNameToChainId(shortName: string) {
 export async function parseQuery(id: string, type: ResolverType, query) {
   let address = id;
   let network = '1';
-  let networkId: string | null = null;
+  let networkId: string | undefined = undefined;
 
   // Resolve format
   // let format;


### PR DESCRIPTION
This PR fix an issue where the legacy url for the `space/ADDRESS` endpoint (without network prefix) was not working as intended, due to an issue when setting the missing network prefix 

This result in those 2 url not returning the same result

- http://localhost:3008/space/s:test.wa0x6e.eth?resolver=space
- http://localhost:3008/space/test.wa0x6e.eth?resolver=space