### PR TITLE
feat: add CoinGecko token image resolver

### DIFF
--- a/src/constants.json
+++ b/src/constants.json
@@ -6,7 +6,7 @@
   "resolvers": {
     "avatar": ["snapshot", "ens", "lens", "farcaster", "starknet"],
     "user-cover": ["user-cover"],
-    "token": ["trustwallet", "zapper"],
+    "token": ["trustwallet", "zapper", "coingecko"],
     "space": ["space"],
     "space-cover": ["space-cover"],
     "space-sx": ["space-sx"],

--- a/src/resolvers/coingecko.ts
+++ b/src/resolvers/coingecko.ts
@@ -13,7 +13,7 @@ const COINGECKO_ASSET_PLATFORMS = {
   42161: 'arbitrum-one'
 };
 
-export default async function resolve(address, chainId) {
+export default async function resolve(address: string, chainId: string) {
   if (!API_KEY) return false;
 
   try {

--- a/src/resolvers/coingecko.ts
+++ b/src/resolvers/coingecko.ts
@@ -18,6 +18,9 @@ export default async function resolve(address: string, chainId: string) {
 
   try {
     const assetPlatformId = COINGECKO_ASSET_PLATFORMS[chainId];
+
+    if (!assetPlatformId) return false;
+
     const checksum = getAddress(address);
     const url = `https://pro-api.coingecko.com/api/v3/coins/${assetPlatformId}/contract/${checksum}`;
 

--- a/src/resolvers/coingecko.ts
+++ b/src/resolvers/coingecko.ts
@@ -14,12 +14,16 @@ const COINGECKO_ASSET_PLATFORMS = {
 };
 
 export default async function resolve(address, chainId) {
+  if (!API_KEY) return false;
+
   try {
     const assetPlatformId = COINGECKO_ASSET_PLATFORMS[chainId];
     const checksum = getAddress(address);
-    const url = `https://pro-api.coingecko.com/api/v3/coins/${assetPlatformId}/contract/${checksum}?x_cg_pro_api_key=${API_KEY}`;
+    const url = `https://pro-api.coingecko.com/api/v3/coins/${assetPlatformId}/contract/${checksum}`;
 
-    const data = await fetch(url).then(res => res.json());
+    const data = await fetch(url, { headers: { 'x-cg-pro-api-key': API_KEY } }).then(res =>
+      res.json()
+    );
     const input = await fetchHttpImage(data?.image?.large);
     return await resize(input, max, max);
   } catch (e) {

--- a/src/resolvers/coingecko.ts
+++ b/src/resolvers/coingecko.ts
@@ -1,0 +1,28 @@
+import { getAddress } from '@ethersproject/address';
+import { resize } from '../utils';
+import { max } from '../constants.json';
+import { fetchHttpImage } from './utils';
+
+const API_KEY = process.env.COINGECKO_API_KEY;
+
+const COINGECKO_ASSET_PLATFORMS = {
+  1: 'ethereum',
+  10: 'optimistic-ethereum',
+  137: 'polygon-pos',
+  8453: 'base',
+  42161: 'arbitrum-one'
+};
+
+export default async function resolve(address, chainId) {
+  try {
+    const assetPlatformId = COINGECKO_ASSET_PLATFORMS[chainId];
+    const checksum = getAddress(address);
+    const url = `https://pro-api.coingecko.com/api/v3/coins/${assetPlatformId}/contract/${checksum}?x_cg_pro_api_key=${API_KEY}`;
+
+    const data = await fetch(url).then(res => res.json());
+    const input = await fetchHttpImage(data?.image?.large);
+    return await resize(input, max, max);
+  } catch (e) {
+    return false;
+  }
+}

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -2,6 +2,7 @@ import blockie from './blockie';
 import jazzicon from './jazzicon';
 import ens from './ens';
 import trustwallet from './trustwallet';
+import coingecko from './coingecko';
 import {
   resolveUserAvatar as sResolveUserAvatar,
   resolveUserCover as sResolveUserCover,
@@ -20,6 +21,7 @@ export default {
   jazzicon,
   ens,
   trustwallet,
+  coingecko,
   snapshot: sResolveUserAvatar,
   'user-cover': sResolveUserCover,
   space: sResolveSpaceAvatar,


### PR DESCRIPTION
### Summary

This pull request introduces a new resolver for tokens using CoinGecko API, this get a much wider coverage than trustwallet or zapper, including tokens on Base like AIXBT or USDC. The config var `COINGECKO_API_KEY` is already available in DigitalOcean, I can share it to you by PM.

Closes https://github.com/snapshot-labs/workflow/issues/346

### How to test

- Disable cache
- Try AIXBT on Base: http://localhost:3008/token/eip155:8453:0x4f9fd6be4a90f2620860d680c0d4d5fb53d1a825?s=64
- Try USDC on Base: http://localhost:3008/token/eip155:8453:0x833589fcd6edb6e08f4c7c32d4f71b54bda02913?s=64
