### PR TITLE
fix: exclude empty address from lookup_address

### DIFF
--- a/src/addressResolvers/index.ts
+++ b/src/addressResolvers/index.ts
@@ -8,7 +8,8 @@ import {
   normalizeAddresses,
   normalizeHandles,
   withoutEmptyValues,
-  mapOriginalInput
+  mapOriginalInput,
+  withoutEmptyAddress
 } from './utils';
 import { Address, Handle } from '../utils';
 import { timeAddressResolverResponse as timeResponse } from '../helpers/metrics';
@@ -22,7 +23,6 @@ const RESOLVERS = [
 ];
 const MAX_LOOKUP_ADDRESSES = 50;
 const MAX_RESOLVE_NAMES = 5;
-const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000';
 
 async function _call(fnName: string, input: string[], maxInputLength: number) {
   if (input.length > maxInputLength) {
@@ -34,36 +34,33 @@ async function _call(fnName: string, input: string[], maxInputLength: number) {
 
   if (input.length === 0) return {};
 
-  return withoutEmptyValues(
-    await cache(input, async (_input: string[]) => {
-      const results = await Promise.all(
-        RESOLVERS.map(async r => {
-          const end = timeResponse.startTimer({
-            provider: r.NAME,
-            method: fnName
-          });
-          let result = {};
-          let status = 0;
+  return withoutEmptyAddress(
+    withoutEmptyValues(
+      await cache(input, async (_input: string[]) => {
+        const results = await Promise.all(
+          RESOLVERS.map(async r => {
+            const end = timeResponse.startTimer({
+              provider: r.NAME,
+              method: fnName
+            });
+            let result = {};
+            let status = 0;
 
-          try {
-            result = await r[fnName](_input);
-            status = 1;
-          } catch (e) {}
-          end({ status });
+            try {
+              result = await r[fnName](_input);
+              status = 1;
+            } catch (e) {}
+            end({ status });
 
-          return result;
-        })
-      );
+            return result;
+          })
+        );
 
-      return Object.fromEntries(
-        _input.map(item => [
-          item,
-          results
-            .map(r => (item === EMPTY_ADDRESS && fnName === 'lookupAddresses' ? '' : r[item]))
-            .filter(i => !!i)[0] || ''
-        ])
-      );
-    })
+        return Object.fromEntries(
+          _input.map(item => [item, results.map(r => r[item]).filter(i => !!i)[0] || ''])
+        );
+      })
+    )
   );
 }
 

--- a/src/addressResolvers/index.ts
+++ b/src/addressResolvers/index.ts
@@ -22,6 +22,7 @@ const RESOLVERS = [
 ];
 const MAX_LOOKUP_ADDRESSES = 50;
 const MAX_RESOLVE_NAMES = 5;
+const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000';
 
 async function _call(fnName: string, input: string[], maxInputLength: number) {
   if (input.length > maxInputLength) {
@@ -55,7 +56,12 @@ async function _call(fnName: string, input: string[], maxInputLength: number) {
       );
 
       return Object.fromEntries(
-        _input.map(item => [item, results.map(r => r[item]).filter(i => !!i)[0] || ''])
+        _input.map(item => [
+          item,
+          results
+            .map(r => (item === EMPTY_ADDRESS && fnName === 'lookupAddresses' ? '' : r[item]))
+            .filter(i => !!i)[0] || ''
+        ])
       );
     })
   );

--- a/src/addressResolvers/utils.ts
+++ b/src/addressResolvers/utils.ts
@@ -2,6 +2,8 @@ import snapshot from '@snapshot-labs/snapshot.js';
 import { getAddress } from '@ethersproject/address';
 import { Address, Handle } from '../utils';
 
+const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000';
+
 const broviderUrl = process.env.BROVIDER_URL || 'https://rpc.snapshot.org';
 
 export class FetchError extends Error {}
@@ -20,6 +22,10 @@ export function provider(network: string) {
 
 export function withoutEmptyValues(obj: Record<string, any>) {
   return Object.fromEntries(Object.entries(obj).filter(([, value]) => value));
+}
+
+export function withoutEmptyAddress(obj: Record<string, any>) {
+  return Object.fromEntries(Object.entries(obj).filter(([key]) => key !== EMPTY_ADDRESS));
 }
 
 export function normalizeAddresses(addresses: Address[]): Address[] {

--- a/test/integration/addressResolvers/utils.test.ts
+++ b/test/integration/addressResolvers/utils.test.ts
@@ -1,4 +1,4 @@
-import { normalizeHandles } from '../../../src/addressResolvers/utils';
+import { normalizeHandles, withoutEmptyAddress } from '../../../src/addressResolvers/utils';
 
 describe('utils', () => {
   describe('normalizeHandles', () => {
@@ -8,6 +8,41 @@ describe('utils', () => {
     it('should return only domain-like values', () => {
       // @ts-ignore
       expect(normalizeHandles([...INVALID_DOMAINS, ...VALID_DOMAINS])).toEqual([...VALID_DOMAINS]);
+    });
+  });
+
+  describe('withoutEmptyAddress', () => {
+    const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+    it('should remove entry with EMPTY_ADDRESS key', () => {
+      const input = {
+        [EMPTY_ADDRESS]: 'some value'
+      };
+      expect(withoutEmptyAddress(input)).toEqual({});
+    });
+
+    it('should keep normal entries', () => {
+      const input = {
+        '0x123': 'value1',
+        '0x456': 'value2'
+      };
+      expect(withoutEmptyAddress(input)).toEqual(input);
+    });
+
+    it('should handle mixed entries', () => {
+      const input = {
+        [EMPTY_ADDRESS]: 'empty',
+        '0x123': 'value1',
+        '0x456': 'value2'
+      };
+      expect(withoutEmptyAddress(input)).toEqual({
+        '0x123': 'value1',
+        '0x456': 'value2'
+      });
+    });
+
+    it('should handle empty object', () => {
+      expect(withoutEmptyAddress({})).toEqual({});
     });
   });
 });


### PR DESCRIPTION
Fix #336

Fix issue where using `lookup_address` on the empty address `0x0000000000000000000000000000000000000000` was returning a handle for that address.

This handle is currently coming from lens, which is returning all those results when querying this empty address

```json
{
  '0xf7a9c91e71EE61c82395Ec85ec2bb5313CD52FFc': 'aleyy.lens',
  '0xcdb631b220cC680F8d756b3A0a0f4c1C271887a2': 'andy188.lens',
  '0x944b12BE4048294fcB3b3f760E0aBaf5D0aAF099': '0xmoc.lens',
  '0x3da94A101245B9b3815f1DdeCD532bc335a9361C': 'brave361.lens',
  '0xAB0e4Da0A57A3eBf7f7c84fB618698Cff9BCd936': '6jioper.lens',
  '0x4c8B3A2f23C377bC90288a38068EEB23050Ae709': '0xlusifer.lens',
  '0x14d9b0d725b96bE978eDadC322b6E20C74dCBCA7': '0o960.lens',
  '0x0ce2895AA13E7536668fD660BD1742f3510F31C3': 'roico14.lens',
  '0x3Ae169fB721EA2990927bB43fd81203Af34cADC6': 'cati12.lens',
  '0xc3A40bE5e57580F36921477d29b737778381b7f5': 'permanaksm.lens',
  '0xB77808fab77cfAB3134EC69a4E2D3Bcf22E5619B': 'artem_xyz.lens',
  '0xf4938d20c6F8d6540bEB809B732198c9c3F811ac': 'tintinstin.lens',
  '0x7D85fCbB505D48E6176483733b62b51704e0bF95': 'luminaenvisions.lens',
  '0x314bD6c798Cd5c48bBed592B093501A6837Bf29c': 'subathon.lens',
  '0xe552f41C9F28f91161D3c40777231eD36C2C6815': 'sanook.lens',
  '0xaaEBA2c3e5feB70fe0cCDd97747295A5aDb76639': 'jazzmin.lens',
  '0x4D604CB70554C2a877Fdbfcbf85d745D33c04f3b': 'unlonelytv.lens',
  '0x545387c9EdbEE1Bd9F4780a27c9c2bBFB3F4925f': 'tukangngopi.lens',
  '0x000000000000000000000000000000000000dEaD': 'sometiiimes.lens',
  '0x458c4150E910fC86De38D9C31da89386dA4a419c': 'chloeee.lens',
  '0x3E7eE513364471fe8139B5b6223056fe35EcDcAD': 'oxbaertomerz.lens',
  '0x0422E56960B3271ad6668D905D30DD438f30c2Bc': 'gusit.lens',
  '0xE37761B727bC9202499c63bFCa73C3dab0cea329': 'cryptocortes.lens',
  '0x2f2CCA82d337cc71AA89394CDeaCee35cDD7C5C5': 'vagrant.lens',
  '0xee1D4cE0182a8E9fb3c803313EDdFdEF3c12423c': 'quawa.lens',
  '0x0000000000000000000000000000000000000000': 'shogo_universe.lens',
  '0xdCCac741a7Cd7d317f05b953D879e4D5262e0d91': 'apeshit.lens',
  '0x5f7Bb4cFAdbc0a0F5c88B9b30c33bf0Ca21a255f': 'perfect0.lens',
  '0x5BE6f3c9b81eeAEaBC56D7436d68e145B9440e52': 'jadlb21.lens'
}
```

This PR will fix the issue by putting a check on the high level, and remove any results from all providers for the empty address

This issue is assigning a name to this address, making profile https://snapshot.box/#/profile/0x0000000000000000000000000000000000000000 looks like 

![Screenshot 2025-01-22 at 23 58 45](https://github.com/user-attachments/assets/51fe132c-6276-49f8-94fb-e056d61cd44d)

### How to test 

```bash
 curl --location 'http://localhost:3008' \
--header 'Content-Type: application/json' \
--data '{
    "method": "lookup_addresses",
    "params": [
        "0x0000000000000000000000000000000000000000", "0x91FD2c8d24767db4Ece7069AA27832ffaf8590f3"
    ]
}'
```

Should not return results for the empty address anymore

```
{"jsonrpc":"2.0","result":{"0x91FD2c8d24767db4Ece7069AA27832ffaf8590f3":"℞aphaël-Daniel de la Poubelle『⚡』"},"id":null}
```