### PR TITLE
fix: set timeout for unstoppable domains resolver

### DIFF
--- a/src/addressResolvers/unstoppableDomains.ts
+++ b/src/addressResolvers/unstoppableDomains.ts
@@ -12,7 +12,7 @@ import { Address, Handle } from '../utils';
 
 export const NAME = 'Unstoppable Domains';
 const NETWORK = '137';
-const provider = getProvider(NETWORK);
+const provider = getProvider(NETWORK, { timeout: 5e3 });
 const ABI = [
   'function reverseNameOf(address addr) view returns (string reverseUri)',
   'function ownerOf(uint256 tokenId) external view returns (address address)'

--- a/src/addressResolvers/utils.ts
+++ b/src/addressResolvers/utils.ts
@@ -16,8 +16,11 @@ export function isStarknetAddress(address: Address): boolean {
   return /^0x[a-fA-F0-9]{64}$/.test(address);
 }
 
-export function provider(network: string) {
-  return snapshot.utils.getProvider(network, { broviderUrl });
+export function provider(
+  network: string,
+  providerOptions: { broviderUrl?: string; timeout?: number } = { broviderUrl, timeout: 5e3 }
+) {
+  return snapshot.utils.getProvider(network, providerOptions);
 }
 
 export function withoutEmptyValues(obj: Record<string, any>) {


### PR DESCRIPTION
Depends on https://github.com/snapshot-labs/snapshot.js/pull/1114

This PR will use the new option in the SDK to set a custom timeout when connecting to brovider.

This will let us set the same timeout value (5 seconds) for all address resolvers.

UnnstoppableDomain not having a timeout was making all address resolvers request respond after 25 seconds, when brovider node is having issues.