### PR TITLE
feat: add support for offchain ens name resolving

### DIFF
--- a/src/addressResolvers/ens.ts
+++ b/src/addressResolvers/ens.ts
@@ -87,7 +87,6 @@ export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Ad
     if (!isSilencedError(e)) {
       capture(e, { input: { handles: normalizedHandles } });
     }
-    throw new FetchError();
   }
 
   const unresolvedHandles = normalizedHandles.filter(handle => !results[handle]);
@@ -107,7 +106,11 @@ export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Ad
         results[handle] = '';
       }
     });
-  } catch (e) {}
+  } catch (e) {
+    if (!isSilencedError(e)) {
+      capture(e, { input: { handles: normalizedHandles } });
+    }
+  }
 
   return results;
 }

--- a/src/addressResolvers/ens.ts
+++ b/src/addressResolvers/ens.ts
@@ -102,8 +102,6 @@ export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Ad
       const result = providerResults[index];
       if (result.status === 'fulfilled' && result.value) {
         results[handle] = getAddress(result.value);
-      } else {
-        results[handle] = '';
       }
     });
   } catch (e) {


### PR DESCRIPTION
Toward https://github.com/snapshot-labs/workflow/issues/485

Add support for ENS names offchain resolution

### Test

```shell
curl --location 'http://localhost:3008' \
--header 'Content-Type: application/json' \
--data '{
    "method": "resolve_names",
    "params": [
        "defi.app",
        "lucemans.cb.id",
        "lucemans.uni.eth",
        "ulas.clv.eth",
        "lucemans.lens.xyz"
    ]
}' | jq
``` 

It should now return results

```json
{
  "jsonrpc": "2.0",
  "result": {
    "defi.app": "0x7aeB96261e9dC2C9f01BaE6A516Df80a5a98c7eB",
    "lucemans.cb.id": "0x4e7abb71BEe38011c54c30D0130c0c71Da09222b",
    "lucemans.uni.eth": "0x225f137127d9067788314bc7fcc1f36746a3c3B5",
    "ulas.clv.eth": "0xd883E2d407361049dd3DACE2fF4278D75BC11d2A"
  },
  "id": null
}
```