### PR TITLE
fix: make sure chainIds are strings and unique

### DIFF
--- a/src/lookupDomains/index.ts
+++ b/src/lookupDomains/index.ts
@@ -19,7 +19,8 @@ export default async function lookupDomains(
   chains: string | string[] = ['1']
 ): Promise<Handle[]> {
   const promises: Promise<Handle[]>[] = [];
-  const chainIds = Array.isArray(chains) ? chains : [chains];
+  let chainIds = Array.isArray(chains) ? chains : [chains];
+  chainIds = [...new Set(chainIds.map(String))];
 
   if (!isAddress(address)) return [];
 


### PR DESCRIPTION
Right now UI send chainIds as Int, we need to convert it into string

### How to test:

Send request with:
```bash
curl --location 'http://localhost:3008' \
--header 'Content-Type: application/json' \
--data '{
    "method": "lookup_domains",
    "params": "0x24F15402C6Bb870554489b2fd2049A85d75B982f",
    "network": 1
}'
```