### PR TITLE
fix: mute server error from lens

### DIFF
--- a/src/addressResolvers/lens.ts
+++ b/src/addressResolvers/lens.ts
@@ -4,6 +4,7 @@ import { graphQlCall, Address, Handle } from '../utils';
 
 export const NAME = 'Lens';
 const API_URL = 'https://api-v2.lens.dev/graphql';
+const MUTED_ERRORS = ['status code 503'];
 
 async function apiCall(filterName: string, filters: string[]) {
   const {
@@ -53,7 +54,7 @@ export async function lookupAddresses(addresses: Address[]): Promise<Record<Addr
       ) || {}
     );
   } catch (e) {
-    if (!isSilencedError(e)) {
+    if (!isSilencedError(e, MUTED_ERRORS)) {
       capture(e, { input: { addresses: normalizedAddresses } });
     }
 
@@ -73,7 +74,7 @@ export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Ad
       Object.fromEntries(items.map(i => [`${i.handle.localName}.lens`, i.handle.ownedBy])) || {}
     );
   } catch (e) {
-    if (!isSilencedError(e)) {
+    if (!isSilencedError(e, MUTED_ERRORS)) {
       capture(e, { input: { handles: normalizedHandles } });
     }
     throw new FetchError();

--- a/src/addressResolvers/utils.ts
+++ b/src/addressResolvers/utils.ts
@@ -48,11 +48,15 @@ export function normalizeHandles(handles: Handle[]): Handle[] {
   return handles.filter(h => /^[^\s]*\.[^\s]*$/.test(h)).map(h => h.toLowerCase());
 }
 
-export function isSilencedError(error: any): boolean {
+export function isSilencedError(error: any, additionalMessages?: string[]): boolean {
   return (
-    ['invalid token ID', 'is not supported', 'execution reverted', 'status=504'].some(m =>
-      error.message?.includes(m)
-    ) ||
+    [
+      'invalid token ID',
+      'is not supported',
+      'execution reverted',
+      'status=504',
+      ...(additionalMessages || [])
+    ].some(m => error.message?.includes(m)) ||
     ['TIMEOUT', 'ECONNABORTED', 'ETIMEDOUT', 'ECONNRESET', 504].some(c =>
       (error.error?.code || error.error?.status || error.code)?.includes(c)
     )


### PR DESCRIPTION
Fix #364 

Stop capturing lens 503 errors

These errors are too frequent, eating our errors quota on sentry, and we don't have any way to solve them, since their api is free and without auth