### PR TITLE
fix: mute 429 errors from lens

### DIFF
--- a/src/addressResolvers/lens.ts
+++ b/src/addressResolvers/lens.ts
@@ -4,7 +4,8 @@ import { graphQlCall, Address, Handle } from '../utils';
 
 export const NAME = 'Lens';
 const API_URL = 'https://api-v2.lens.dev/graphql';
-const MUTED_ERRORS = ['status code 503'];
+// mute not fixable errors, since it's a public API
+const MUTED_ERRORS = ['status code 503', 'status code 429'];
 
 async function apiCall(filterName: string, filters: string[]) {
   const {


### PR DESCRIPTION
Fix https://snapshot-labs.sentry.io/issues/4651451195/events/latest/?notification_uuid=94935e9b-e1ed-438b-abfa-5941ed814c91&project=4505506866593792&referrer=latest-event

This PR will stop logging errors when lens api is returning 429 response.

Those errors can not be fixed, and are just consuming sentry quota