### PR TITLE
fix: handle unclaimed names when fetching shib names owner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,35 @@
 name: Test
+
 on: [push]
+
 jobs:
   test:
-    uses: snapshot-labs/actions/.github/workflows/test.yml@main
-    secrets: inherit
-    with:
-      redis: true
+    name: Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    env:
+      D3_API_KEY_MAINNET: ${{ secrets.D3_API_KEY_MAINNET }}
+      D3_API_KEY_TESTNET: ${{ secrets.D3_API_KEY_TESTNET }}
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+          cache: 'yarn'
+
+      - name: Setup Redis
+        uses: supercharge/redis-github-action@1.7.0
+        with:
+          redis-version: '7'
+
+      - name: Yarn install
+        run: yarn install --frozen-lockfile
+
+      - name: Test
+        run: yarn test
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@snapshot-labs/snapshot-sentry": "^1.5.5",
     "@snapshot-labs/snapshot.js": "^0.12.59",
     "@unstoppabledomains/resolution": "^9.2.2",
+    "@webinterop/dns-connect": "^0.3.1",
     "axios": "^0.25.0",
     "canvas": "^2.9.0",
     "compression": "^1.7.4",

--- a/src/constants.json
+++ b/src/constants.json
@@ -17,10 +17,16 @@
     "1": "https://subgrapher.snapshot.org/subgraph/arbitrum/5XqPmWe6gjyrJtFn9cLy237i4cWw2j9HcUJEXsP5qGtH",
     "11155111": "https://subgrapher.snapshot.org/subgraph/arbitrum/DmMXLtMZnGbQXASJ7p1jfzLUbBYnYUD9zNBTxpkjHYXV"
   },
-  "d3Api": {
-    "109": "https://api-public.d3.app",
-    "157": "https://api-public-stage.d3.app"
+  "d3": {
+    "109": {
+      "apiUrl": "https://api-public.d3.app",
+      "forwarder": "vana"
+     },
+    "157": {
+      "apiUrl": "https://api-public-stage.d3.app",
+      "forwarder": "stage.d3test.vana"
+    }
   },
-  "defaultOffchainNetwork" : "s",
+  "defaultOffchainNetwork": "s",
   "offchainNetworks": ["s", "s-tn"]
 }

--- a/src/getOwner/shibarium.ts
+++ b/src/getOwner/shibarium.ts
@@ -12,7 +12,7 @@ const API_KEYS = {
   [TESTNET]: process.env.D3_API_KEY_TESTNET
 };
 
-async function _getOwner(handle: Handle, chainId: string): Promise<Address> {
+async function getClaimedOwner(handle: Handle, chainId: string): Promise<Address> {
   if (!handle.endsWith(`.${TLD}`) || !constants.d3[chainId]?.apiUrl || !API_KEYS[chainId])
     return EMPTY_ADDRESS;
 
@@ -40,7 +40,7 @@ async function _getOwner(handle: Handle, chainId: string): Promise<Address> {
   return data.owner || '';
 }
 
-async function resolvedAddress(handle: Handle, chainId: string): Promise<Address> {
+async function getResolvedAddress(handle: Handle, chainId: string): Promise<Address> {
   const dnsConnect = new DNSConnect({ dns: { forwarderDomain: constants.d3[chainId].forwarder } });
 
   return (await dnsConnect.resolve(handle, NETWORK)) || EMPTY_ADDRESS;
@@ -52,9 +52,9 @@ async function resolvedAddress(handle: Handle, chainId: string): Promise<Address
  * it will return the resolved address.
  **/
 export default async function getOwner(handle: Handle, chainId = MAINNET): Promise<Address> {
-  const address = await _getOwner(handle, chainId);
+  const address = await getClaimedOwner(handle, chainId);
 
   if (address !== '') return address;
 
-  return resolvedAddress(handle, chainId);
+  return getResolvedAddress(handle, chainId);
 }

--- a/src/getOwner/shibarium.ts
+++ b/src/getOwner/shibarium.ts
@@ -12,7 +12,7 @@ const API_KEYS = {
   [TESTNET]: process.env.D3_API_KEY_TESTNET
 };
 
-async function getClaimedOwner(handle: Handle, chainId: string): Promise<Address> {
+async function getClaimedOwner(handle: Handle, chainId: string): Promise<Address | false> {
   if (!handle.endsWith(`.${TLD}`) || !constants.d3[chainId]?.apiUrl || !API_KEYS[chainId])
     return EMPTY_ADDRESS;
 
@@ -37,7 +37,7 @@ async function getClaimedOwner(handle: Handle, chainId: string): Promise<Address
   }
 
   // owner field will be missing on unclaimed names
-  return data.owner || '';
+  return data.owner || false;
 }
 
 async function getResolvedAddress(handle: Handle, chainId: string): Promise<Address> {
@@ -54,7 +54,7 @@ async function getResolvedAddress(handle: Handle, chainId: string): Promise<Addr
 export default async function getOwner(handle: Handle, chainId = MAINNET): Promise<Address> {
   const address = await getClaimedOwner(handle, chainId);
 
-  if (address !== '') return address;
+  if (address) return address;
 
   return getResolvedAddress(handle, chainId);
 }

--- a/src/getOwner/shibarium.ts
+++ b/src/getOwner/shibarium.ts
@@ -1,21 +1,23 @@
+import { DNSConnect } from '@webinterop/dns-connect';
 import { Address, EMPTY_ADDRESS, Handle } from '../utils';
 import constants from '../constants.json';
 
 const MAINNET = '109';
 const TESTNET = '157';
 const TLD = 'shib';
+const NETWORK = 'BONE';
 
 const API_KEYS = {
   [MAINNET]: process.env.D3_API_KEY_MAINNET,
   [TESTNET]: process.env.D3_API_KEY_TESTNET
 };
 
-export default async function getOwner(handle: Handle, chainId = MAINNET): Promise<Address> {
-  if (!handle.endsWith(`.${TLD}`) || !constants.d3Api[chainId] || !API_KEYS[chainId])
+async function _getOwner(handle: Handle, chainId: string): Promise<Address> {
+  if (!handle.endsWith(`.${TLD}`) || !constants.d3[chainId]?.apiUrl || !API_KEYS[chainId])
     return EMPTY_ADDRESS;
 
   const response = await fetch(
-    `${constants.d3Api[chainId]}/v1/partner/token/${handle.replace(/\.shib$/, '')}/shib`,
+    `${constants.d3[chainId].apiUrl}/v1/partner/token/${handle.replace(/\.shib$/, '')}/${TLD}`,
     {
       method: 'GET',
       headers: {
@@ -34,5 +36,25 @@ export default async function getOwner(handle: Handle, chainId = MAINNET): Promi
     return EMPTY_ADDRESS;
   }
 
-  return data.owner;
+  // owner field will be missing on unclaimed names
+  return data.owner || '';
+}
+
+async function resolvedAddress(handle: Handle, chainId: string): Promise<Address> {
+  const dnsConnect = new DNSConnect({ dns: { forwarderDomain: constants.d3[chainId].forwarder } });
+
+  return (await dnsConnect.resolve(handle, NETWORK)) || EMPTY_ADDRESS;
+}
+
+/**
+ * Returns the owner of a Shibarium handle.
+ * In case the name has not been claimed (when bought with a credit card),
+ * it will return the resolved address.
+ **/
+export default async function getOwner(handle: Handle, chainId = MAINNET): Promise<Address> {
+  const address = await _getOwner(handle, chainId);
+
+  if (address !== '') return address;
+
+  return resolvedAddress(handle, chainId);
 }

--- a/src/lookupDomains/shibarium.ts
+++ b/src/lookupDomains/shibarium.ts
@@ -15,11 +15,11 @@ export default async function lookupDomains(
   address: Address,
   chainId = MAINNET
 ): Promise<Handle[]> {
-  if (!constants.d3Api[chainId] || !API_KEYS[chainId]) return [];
+  if (!constants.d3[chainId]?.apiUrl || !API_KEYS[chainId]) return [];
 
   try {
     const response = await fetch(
-      `${constants.d3Api[chainId]}/v1/partner/tokens/EVM/${address}?limit=25&skip=0`,
+      `${constants.d3[chainId].apiUrl}/v1/partner/tokens/EVM/${address}?limit=25&skip=0`,
       {
         headers: { 'Content-Type': 'application/json', 'Api-Key': API_KEYS[chainId] }
       }

--- a/test/integration/getOwner.test.ts
+++ b/test/integration/getOwner.test.ts
@@ -1,19 +1,42 @@
 import getOwner from '../../src/getOwner';
 
 describe('getOwner', () => {
-  it('should return an address for shibarium', async () => {
-    const result = await getOwner('boorger.shib', '109');
-    expect(result).toContain('0x220bc93D88C0aF11f1159eA89a885d5ADd3A7Cf6');
+  describe('on claimed names', () => {
+    it('should return an address for shibarium', async () => {
+      const result = await getOwner('boorger.shib', '109');
+      expect(result).toContain('0x220bc93D88C0aF11f1159eA89a885d5ADd3A7Cf6');
+    });
+
+    it('should return an address for puppynet', async () => {
+      const result = await getOwner('snapshot-test-1.shib', '157');
+      expect(result).toContain('0x91FD2c8d24767db4Ece7069AA27832ffaf8590f3');
+    });
+  });
+
+  describe('on unclaimed names', () => {
+    // This may stop working since we don't own this domain.
+    // In such case, go to https://www.shibariumscan.io/name-domains?only_active=true
+    // and find a domain that is not claimed (owner = 0x1A039289Af80a806f562396569fBC6d4A862C25c),
+    // but has a resolved address.
+    it('should return an address for shibarium', async () => {
+      const result = await getOwner('scoobysnacks.shib', '109');
+      expect(result).toContain('0xa226a85fF338f5015cd3Da6a987CD08D70619977');
+    });
+
+    it('should return an address for puppynet', async () => {
+      const result = await getOwner('snapshot-test-unclaimed.shib', '157');
+      expect(result).toContain('0x91FD2c8d24767db4Ece7069AA27832ffaf8590f3');
+    });
+
+    it('should return an empty address when the name does not have a primary names', async () => {
+      const result = await getOwner('snapshot-test-unclaimed-unresolved.shib', '157');
+      expect(result).toContain('0x0000000000000000000000000000000000000000');
+    });
   });
 
   it('should return an empty address for shibarium when domain does not exist', async () => {
     const result = await getOwner('invalid-domain-h.shib', '109');
     expect(result).toContain('0x0000000000000000000000000000000000000000');
-  });
-
-  it('should return an address for puppynet', async () => {
-    const result = await getOwner('systematize752253.shib', '157');
-    expect(result).toContain('0xc4B06a671831CdD66fdA1A287263103103DEC80D');
   });
 
   it('should return an empty address for puppynet when domain does not exist', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2413,7 +2413,7 @@
   resolved "https://registry.yarnpkg.com/@stablelib/wipe/-/wipe-1.0.1.tgz#d21401f1d59ade56a62e139462a97f104ed19a36"
   integrity sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg==
 
-"@starknet-io/types-js@^0.7.7":
+"@starknet-io/types-js@^0.7.7", "starknet-types-07@npm:@starknet-io/types-js@^0.7.7":
   version "0.7.7"
   resolved "https://registry.yarnpkg.com/@starknet-io/types-js/-/types-js-0.7.7.tgz#444be5e4e585ec6f599d42d3407280d98b2dfdf8"
   integrity sha512-WLrpK7LIaIb8Ymxu6KF/6JkGW1sso988DweWu7p5QY/3y7waBIiPvzh27D9bX5KIJNRDyOoOVoHVEKYUYWZ/RQ==
@@ -2686,6 +2686,11 @@
     js-sha256 "^0.9.0"
     js-sha3 "^0.8.0"
 
+"@webinterop/dns-connect@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@webinterop/dns-connect/-/dns-connect-0.3.1.tgz#90349d38a856d2510299a9adfea382b0cced64dc"
+  integrity sha512-dSaCIYHEqfgKK/aZO518O42DLRIefbFxMezq05wABoHyDABneN5seUHsYEAciTRdbmQqflH7/k4Iy2BTkWg8ew==
+
 abab@^2.0.5, abab@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.6.tgz#41b80f2c871d19686216b82309231cfd3cb3d291"
@@ -2696,7 +2701,7 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
-"abi-wan-kanabi-v1@npm:abi-wan-kanabi@^1.0.3":
+"abi-wan-kanabi-v1@npm:abi-wan-kanabi@^1.0.3", abi-wan-kanabi@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/abi-wan-kanabi/-/abi-wan-kanabi-1.0.3.tgz#0d8607f2a2ccb2151a69debea1c3bb68b76c5aa2"
   integrity sha512-Xwva0AnhXx/IVlzo3/kwkI7Oa7ZX7codtcSn+Gmoa2PmjGPF/0jeVud9puasIPtB7V50+uBdUj4Mh3iATqtBvg==
@@ -2707,28 +2712,7 @@ abbrev@1:
     typescript "^4.9.5"
     yargs "^17.7.2"
 
-"abi-wan-kanabi-v2@npm:abi-wan-kanabi@^2.1.1":
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/abi-wan-kanabi/-/abi-wan-kanabi-2.2.2.tgz#82c48e8fa08d9016cf92d3d81d494cc60e934693"
-  integrity sha512-sTCv2HyNIj1x2WFUoc9oL8ZT9liosrL+GoqEGZJK1kDND096CfA7lwx06vLxLWMocQ41FQXO3oliwoh/UZHYdQ==
-  dependencies:
-    ansicolors "^0.3.2"
-    cardinal "^2.1.1"
-    fs-extra "^10.0.0"
-    yargs "^17.7.2"
-
-abi-wan-kanabi@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/abi-wan-kanabi/-/abi-wan-kanabi-1.0.3.tgz#0d8607f2a2ccb2151a69debea1c3bb68b76c5aa2"
-  integrity sha512-Xwva0AnhXx/IVlzo3/kwkI7Oa7ZX7codtcSn+Gmoa2PmjGPF/0jeVud9puasIPtB7V50+uBdUj4Mh3iATqtBvg==
-  dependencies:
-    abi-wan-kanabi "^1.0.1"
-    fs-extra "^10.0.0"
-    rome "^12.1.3"
-    typescript "^4.9.5"
-    yargs "^17.7.2"
-
-abi-wan-kanabi@^2.2.2:
+"abi-wan-kanabi-v2@npm:abi-wan-kanabi@^2.1.1", abi-wan-kanabi@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/abi-wan-kanabi/-/abi-wan-kanabi-2.2.2.tgz#82c48e8fa08d9016cf92d3d81d494cc60e934693"
   integrity sha512-sTCv2HyNIj1x2WFUoc9oL8ZT9liosrL+GoqEGZJK1kDND096CfA7lwx06vLxLWMocQ41FQXO3oliwoh/UZHYdQ==
@@ -6532,11 +6516,6 @@ stack-utils@^2.0.3:
   integrity sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==
   dependencies:
     escape-string-regexp "^2.0.0"
-
-"starknet-types-07@npm:@starknet-io/types-js@^0.7.7":
-  version "0.7.7"
-  resolved "https://registry.yarnpkg.com/@starknet-io/types-js/-/types-js-0.7.7.tgz#444be5e4e585ec6f599d42d3407280d98b2dfdf8"
-  integrity sha512-WLrpK7LIaIb8Ymxu6KF/6JkGW1sso988DweWu7p5QY/3y7waBIiPvzh27D9bX5KIJNRDyOoOVoHVEKYUYWZ/RQ==
 
 starknet@^5.19.3:
   version "5.29.0"


### PR DESCRIPTION
This PR fix an issue with unclaimed .shib names.

### What is an unclaimed name ?

.shib names can be bought with web2 means, such as credit card. Names bought via such mean will not be associated to an EOA wallet, and retrieving the owner via d3 api will not return owner field.

![Screenshot 2025-04-14 at 13 05 28](https://github.com/user-attachments/assets/196d1333-4908-4f75-8d5a-07f433cd359f)

### Fix

In those cases, we should fallback, and return the resolved address instead, and consider the resolved address as owner, like we already do with the other offchain resolved address (like coinbase .cb.id names).

This will fix the error encountered in the ui pr: https://github.com/snapshot-labs/sx-monorepo/actions/runs/14441352799/job/40492017489?pr=1312

Resolving names are done via https://docs.d3.app/resolve-d3-names#d3-connect-sdk

### Tests

```shell
curl --location 'http://localhost:3008' \
--header 'Content-Type: application/json' \
--data '{
    "method": "get_owner",
    "params": "renato.shib",
    "network": "157"
}'
```

It should returned the resolved address as stated here instead of the empty address: https://puppyscan.shib.io/name-domains?name=renato.shib&only_active=true