### PR TITLE
feat: resolve shibarium names and addresses

### DIFF
--- a/src/addressResolvers/index.ts
+++ b/src/addressResolvers/index.ts
@@ -3,6 +3,7 @@ import * as lensResolver from './lens';
 import * as unstoppableDomainResolver from './unstoppableDomains';
 import * as starknetResolver from './starknet';
 import * as snapshotResolver from './snapshot';
+import * as shibariumResolver from './shibarium';
 import cache, { clear } from './cache';
 import {
   normalizeAddresses,
@@ -19,7 +20,8 @@ const RESOLVERS = [
   ensResolver,
   unstoppableDomainResolver,
   lensResolver,
-  starknetResolver
+  starknetResolver,
+  shibariumResolver
 ];
 const MAX_LOOKUP_ADDRESSES = 50;
 const MAX_RESOLVE_NAMES = 5;

--- a/src/addressResolvers/shibarium.ts
+++ b/src/addressResolvers/shibarium.ts
@@ -1,0 +1,62 @@
+import { capture } from '@snapshot-labs/snapshot-sentry';
+import { Address, Handle } from '../utils';
+import { FetchError, isSilencedError, withoutEmptyValues } from './utils';
+import { DNSConnect } from '@webinterop/dns-connect';
+import constants from '../constants.json';
+
+export const NAME = 'Shibarium';
+const CHAIN_ID = '109';
+const NETWORK = 'BONE';
+const TLD = 'shib';
+
+// TODO: Support unicode names, by converting to punycode
+// see https://docs.d3.app/resolve-d3-names#d3-connect-sdk
+function normalizeHandles(handles: Handle[]): Handle[] {
+  return handles.filter(handle => handle.endsWith(`.${TLD}`));
+}
+
+export async function lookupAddresses(addresses: Address[]): Promise<Record<Address, Handle>> {
+  try {
+    const dnsConnect = new DNSConnect({
+      dns: { forwarderDomain: constants.d3[CHAIN_ID].forwarder }
+    });
+
+    const results = await Promise.all(
+      addresses.map(async address => dnsConnect.reverseResolve(address, NETWORK))
+    );
+
+    return withoutEmptyValues(
+      Object.fromEntries(addresses.map((address, index) => [address, results[index]]))
+    );
+  } catch (e) {
+    if (!isSilencedError(e)) {
+      capture(e, { input: { addresses } });
+    }
+    throw new FetchError();
+  }
+}
+
+export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Address>> {
+  try {
+    const normalizedHandles = normalizeHandles(handles);
+
+    if (normalizedHandles.length === 0) return {};
+
+    const dnsConnect = new DNSConnect({
+      dns: { forwarderDomain: constants.d3[CHAIN_ID].forwarder }
+    });
+
+    const results = await Promise.all(
+      normalizedHandles.map(async handle => dnsConnect.resolve(handle, NETWORK))
+    );
+
+    return withoutEmptyValues(
+      Object.fromEntries(normalizedHandles.map((handle, index) => [handle, results[index]]))
+    );
+  } catch (e) {
+    if (!isSilencedError(e)) {
+      capture(e, { input: { handles } });
+    }
+    throw new FetchError();
+  }
+}

--- a/test/integration/addressResolvers/shibarium.test.ts
+++ b/test/integration/addressResolvers/shibarium.test.ts
@@ -1,0 +1,12 @@
+import { lookupAddresses, resolveNames } from '../../../src/addressResolvers/shibarium';
+import testAddressResolver from './helper';
+
+testAddressResolver({
+  name: 'Shibarium',
+  lookupAddresses,
+  resolveNames,
+  validAddress: '0x220bc93D88C0aF11f1159eA89a885d5ADd3A7Cf6',
+  validDomain: 'boorger.shib',
+  blankAddress: '0x91FD2c8d24767db4Ece7069AA27832ffaf8590f3',
+  invalidDomains: ['domain.crypto', 'domain.eth', 'domain.com', 'inexistent-domain-for-test.shib']
+});


### PR DESCRIPTION
Towards https://github.com/snapshot-labs/workflow/issues/523

This PR adds shibarium to the `lookup_addresses` and `resolve_name`

### How to test

disable the other resolver:

```diff
diff --git a/src/addressResolvers/index.ts b/src/addressResolvers/index.ts
index 7987d57..ed509c2 100644
--- a/src/addressResolvers/index.ts
+++ b/src/addressResolvers/index.ts
@@ -16,11 +16,11 @@ import { Address, Handle } from '../utils';
 import { timeAddressResolverResponse as timeResponse } from '../helpers/metrics';
 
 const RESOLVERS = [
-  snapshotResolver,
-  ensResolver,
-  unstoppableDomainResolver,
-  lensResolver,
-  starknetResolver,
+  // snapshotResolver,
+  // ensResolver,
+  // unstoppableDomainResolver,
+  // lensResolver,
+  // starknetResolver,
   shibariumResolver
 ];
 const MAX_LOOKUP_ADDRESSES = 50;
```

```shell
curl 'http://localhost:3008/' \
  -H 'content-type: application/json' \
  --data-raw '{"method":"resolve_names","params":["boorger.shib", "janhawks.shib"],"network":1}'
```

Should return 

```json
{"jsonrpc":"2.0","result":{"boorger.shib":"0x220bc93D88C0aF11f1159eA89a885d5ADd3A7Cf6","janhawks.shib":"0x98c55D87f5BC731D5E241E16490f021a39213c00"},"id":null}
```

```shell
curl 'http://localhost:3008/' \
  -H 'content-type: application/json' \
  --data-raw '{"method":"lookup_addresses","params":["0x220bc93D88C0aF11f1159eA89a885d5ADd3A7Cf6", "0x98c55D87f5BC731D5E241E16490f021a39213c00"],"network":1}'
```

Should return

```json
{"jsonrpc":"2.0","result":{"0x220bc93D88C0aF11f1159eA89a885d5ADd3A7Cf6":"boorger.shib","0x98c55D87f5BC731D5E241E16490f021a39213c00":"janhawks.shib"},"id":null}
```