### PR TITLE
fix: lookup_domains should default to use all supported mainnet

### DIFF
--- a/src/lookupDomains/ens.ts
+++ b/src/lookupDomains/ens.ts
@@ -3,7 +3,7 @@ import { FetchError, isSilencedError } from '../addressResolvers/utils';
 import { Address, graphQlCall, Handle } from '../utils';
 import constants from '../constants.json';
 
-const DEFAULT_CHAIN_ID = '1';
+export const DEFAULT_CHAIN_ID = '1';
 
 type Domain = {
   name: string;

--- a/src/lookupDomains/index.ts
+++ b/src/lookupDomains/index.ts
@@ -1,13 +1,13 @@
 import { isAddress } from '@ethersproject/address';
 import { Address, Handle } from '../utils';
-import ens from './ens';
-import shibarium from './shibarium';
+import ens, { DEFAULT_CHAIN_ID as ENS_DEFAULT_CHAIN_ID } from './ens';
+import shibarium, { DEFAULT_CHAIN_ID as SHIBARIUM_DEFAULT_CHAIN_ID } from './shibarium';
 
 const RESOLVERS = [ens, shibarium];
 
 export default async function lookupDomains(
   address: Address,
-  chains: string | string[] = ['1']
+  chains: string | string[] = [ENS_DEFAULT_CHAIN_ID, SHIBARIUM_DEFAULT_CHAIN_ID]
 ): Promise<Handle[]> {
   const promises: Promise<Handle[]>[] = [];
   let chainIds = Array.isArray(chains) ? chains : [chains];

--- a/src/lookupDomains/shibarium.ts
+++ b/src/lookupDomains/shibarium.ts
@@ -11,9 +11,11 @@ const API_KEYS = {
   [TESTNET]: process.env.D3_API_KEY_TESTNET
 };
 
+export const DEFAULT_CHAIN_ID = MAINNET;
+
 export default async function lookupDomains(
   address: Address,
-  chainId = MAINNET
+  chainId = DEFAULT_CHAIN_ID
 ): Promise<Handle[]> {
   if (!constants.d3[chainId]?.apiUrl || !API_KEYS[chainId]) return [];
 


### PR DESCRIPTION
When running the `lookup_domains`, like 

```shell
curl --location 'http://localhost:3008' \
--header 'Content-Type: application/json' \
--data '{
    "method": "lookup_domains",
    "params":
        "0x220bc93D88C0aF11f1159eA89a885d5ADd3A7Cf6"

}' | jq
```

it currently only returns ens name, since when missing, the networks params default to `1`

This PR fix the issue by adding shibarium chain id to the default list