### PR TITLE
fix: handle pagination when fetching shibarium domain lookup

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,3 @@
+{
+  "enableAllProjectMcpServers": false
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,3 +1,0 @@
-{
-  "enableAllProjectMcpServers": false
-}

--- a/src/lookupDomains/shibarium.ts
+++ b/src/lookupDomains/shibarium.ts
@@ -27,10 +27,10 @@ export default async function lookupDomains(
 
   try {
     while (hasMore) {
-      try {
-        const controller = new AbortController();
-        const timeoutId = setTimeout(() => controller.abort(), TIMEOUT);
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), TIMEOUT);
 
+      try {
         const response = await fetch(
           `${constants.d3[chainId].apiUrl}/v1/partner/tokens/EVM/${address}?limit=${PAGE_SIZE}&skip=${skip}`,
           {
@@ -38,8 +38,6 @@ export default async function lookupDomains(
             signal: controller.signal
           }
         );
-
-        clearTimeout(timeoutId);
 
         if (response.status === 404) {
           break;
@@ -64,6 +62,8 @@ export default async function lookupDomains(
       } catch (e) {
         capture(e, { input: { address, chainId, skip } });
         break;
+      } finally {
+        clearTimeout(timeoutId);
       }
     }
 

--- a/src/lookupDomains/shibarium.ts
+++ b/src/lookupDomains/shibarium.ts
@@ -47,7 +47,7 @@ export default async function lookupDomains(
           throw new Error(`HTTP ${response.status}: ${response.statusText}`);
         }
 
-        let data;
+        let data: { pageItems?: Array<{ sld: string; tld: string }> };
         try {
           data = await response.json();
         } catch (e) {


### PR DESCRIPTION
This PR fix an issue where the shibarium wallet own more than 25 domains, in which cases, the results from `domain_lookup` will only return max 25 items, due to pagination not being implemented.

This PR will handle pagination when fetching results, as well as some fetching improvement:
- add timeout of 10s for each requests (data are not cached, so user may retry in case some results are missing)
- better error handling, to not return empty data in case requests fail mid-pagination

### Test

```shell
curl 'http://localhost:3008/' \
  -H 'content-type: application/json' \
  --data-raw '{"method":"lookup_domains","params":"0xc7D0445ac2947760b3dD388B8586Adf079972Bf3","network":109}'
```

It should return some results (have not found any wallets owning more than 25, you can try changing the `limit` in the code to force some pagination)
