### PR TITLE
test: fix failing test due to invalid test data

### DIFF
--- a/test/integration/resolvers/ens.test.ts
+++ b/test/integration/resolvers/ens.test.ts
@@ -17,7 +17,7 @@ describe('resolvers', () => {
     }, 10e3);
 
     it('should resolve', async () => {
-      const result = await resolvers.ens('snowowl.eth');
+      const result = await resolvers.ens('fabien.eth');
 
       expect(result).toBeInstanceOf(Buffer);
       return expect(result.length).toBeGreaterThan(1000);

--- a/test/setup-jest.ts
+++ b/test/setup-jest.ts
@@ -1,3 +1,6 @@
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+jest.spyOn(console, 'log').mockImplementation(() => {});
+
 import client from '../src/helpers/redis';
 
 afterAll(async () => {


### PR DESCRIPTION
Fix tests:

- ENS tests were testing using `snowowl.eth` name, which is now broken with the error `{"message":"Error fetching avatar: Provided url or NFT source is broken."}` (see https://metadata.ens.domains/mainnet/avatar/snowowl.eth). Tests switched to use `fabien.eth` instead
- Mute `console.log` in test output

This PR is fixing some of the failing tests, remaining failing tests are due to another code issue, which will be addressed in another PR (https://github.com/stamp-labs/stamp/pull/380)