### PR TITLE
fix: add support for apechain in Coingecko resolver

### DIFF
--- a/src/resolvers/coingecko.ts
+++ b/src/resolvers/coingecko.ts
@@ -10,6 +10,7 @@ const COINGECKO_ASSET_PLATFORMS = {
   10: 'optimistic-ethereum',
   137: 'polygon-pos',
   8453: 'base',
+  33139: 'apechain',
   42161: 'arbitrum-one'
 };
 


### PR DESCRIPTION
### Summary
- added apechain to the asset platforms list

### How to test:
- https://cdn.stamp.fyi/token/eip155:33139:0xd6e4df460d9ba104dfc5dc57db392c177083d20c?s=64 - Doesn't work
- http://localhost:3008/token/eip155:33139:0xd6e4df460d9ba104dfc5dc57db392c177083d20c?s=64 - Should work