### PR TITLE
fix: space-logo image should not be cropped to a square image

### DIFF
--- a/src/resolvers/snapshot.ts
+++ b/src/resolvers/snapshot.ts
@@ -117,7 +117,7 @@ function createPropertyResolver(entity: Entity, property: Property) {
       const url = getUrl(value);
       const input = await fetchHttpImage(url);
 
-      if (property === 'cover') return input;
+      if (['cover', 'logo'].includes(property)) return input;
 
       return await resize(input, max, max);
     } catch (e) {


### PR DESCRIPTION
This PR fix an issue where the space-logo image was forced to a square ratio

After this fix, space-logo can have any ratio

### Test

- Go to http://localhost:3008/space-logo/openagora.eth?w=190&h=38&fit=inside
- The image should not be square anymore