### PR TITLE
fix: use sonic chain id when asking for .sonic domains

### DIFF
--- a/src/lookupDomains/unstoppableDomains.ts
+++ b/src/lookupDomains/unstoppableDomains.ts
@@ -2,7 +2,7 @@ import { capture } from '@snapshot-labs/snapshot-sentry';
 import { FetchError, isSilencedError } from '../addressResolvers/utils';
 import { Address, Handle } from '../utils';
 
-export const DEFAULT_CHAIN_ID = 'unstoppable-domains';
+export const DEFAULT_CHAIN_ID = '146';
 
 const SUPPORTED_TLDS = ['sonic'];
 

--- a/test/integration/lookupDomains.test.ts
+++ b/test/integration/lookupDomains.test.ts
@@ -60,18 +60,12 @@ describe('lookupDomains', () => {
   });
 
   it('should return an array of addresses for unstoppable domains', async () => {
-    const result = await lookupDomains(
-      '0x17af7086649580ab880060c92f46fc931ab3588b',
-      'unstoppable-domains'
-    );
+    const result = await lookupDomains('0x17af7086649580ab880060c92f46fc931ab3588b', '146');
     expect(result).toContain('boorger.sonic');
   });
 
   it('should return an empty array if the address does not own any unstoppable domains', async () => {
-    const result = await lookupDomains(
-      '0x76ece6825602294b87a40d783982d83bb8ebcaf7',
-      'unstoppable-domains'
-    );
+    const result = await lookupDomains('0x76ece6825602294b87a40d783982d83bb8ebcaf7', '146');
     expect(result).toEqual([]);
   });
 });

--- a/test/integration/lookupDomains.test.ts
+++ b/test/integration/lookupDomains.test.ts
@@ -60,7 +60,7 @@ describe('lookupDomains', () => {
   });
 
   it('should return an array of addresses for unstoppable domains', async () => {
-    const result = await lookupDomains('0x17af7086649580ab880060c92f46fc931ab3588b', '146');
+    const result = await lookupDomains('0x220bc93D88C0aF11f1159eA89a885d5ADd3A7Cf6', '146');
     expect(result).toContain('boorger.sonic');
   });
 


### PR DESCRIPTION
The unstoppable domains lookup was using a custom chain id `unstoppable-domain`, since it was created to return domains from various chain ids.

It was now refactored to return only .sonic domain name, this PR will update the accepted chain id to 146 (sonic chain id)