### PR TITLE
fix: fix cache clearing for resolved names

### DIFF
--- a/src/addressResolvers/index.ts
+++ b/src/addressResolvers/index.ts
@@ -86,6 +86,6 @@ export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Ad
   return mapOriginalInput(handles, result);
 }
 
-export function clearCache(input: string): Promise<boolean> {
-  return clear(normalizeAddresses([input])[0]);
+export function clearCache(input: string, type: 'address' | 'name'): Promise<boolean> {
+  return clear(type === 'address' ? normalizeAddresses([input])[0] : normalizeHandles([input])[0]);
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -46,7 +46,7 @@ router.get(`/clear/:type(${TYPE_CONSTRAINTS})/:id`, async (req, res) => {
     let result = false;
 
     if (type === 'address' || type === 'name') {
-      result = await clearCache(id);
+      result = await clearCache(id, type);
     } else {
       const { address, network, w, h, fallback, cb, fit } = await parseQuery(id, type, {
         s: constants.max,


### PR DESCRIPTION
The address resolver cache clearing is currently only handling addresses, and will reject input when passing names (e.g. snapshot.org).

This PR fix the cache clearing function to also handle domain names